### PR TITLE
Including instructions for arm64 processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ For example:
 # Defaults
 > docker run -p 8080:8080 --init openwa/wa-automate
 
+# For arm64 processors
+> docker run --platform linux/arm64 -p 8080:8080 openwa/wa-automate
+
 # Custom webhook, port & socket mode enabled for easy integration with node-red
 > docker run -p 8080:8085 --init openwa/wa-automate -w -p 8085 https://webhook.site.... --socket
 


### PR DESCRIPTION
This change will make easier for users to see what is needed to run wa-automate on docker with Raspberry Pi`s, or other devices with arm64 processors